### PR TITLE
Implement SOP creator React app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# sop-creator
-basic sop creator application
+# SOP Creator
+
+This project is a simple Standard Operating Procedure (SOP) creator built with React, Vite and TailwindCSS.
+
+## Features
+
+- Create SOPs with multiple steps and checklist items
+- Live Markdown preview for step descriptions
+- LocalStorage persistence
+- Export SOP to Markdown or PDF
+- Import SOP from JSON
+- Mobile and desktop responsive layout
+
+## Development
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start development server
+   ```bash
+   npm run dev
+   ```
+3. Build for production
+   ```bash
+   npm run build
+   ```
+
+## Folder Structure
+
+- `src/components` – Reusable components
+- `src/pages` – Application pages
+- `src/lib` – Utility modules
+- `src/styles` – TailwindCSS styles
+
+## Deployment
+
+The app can be deployed to platforms like Vercel. Ensure that `npm run build` succeeds before deploying.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SOP Creator</title>
+    <script type="module" src="/src/main.jsx"></script>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "sop-creator",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.12.1",
+    "markdown-it": "^13.0.1",
+    "html2pdf.js": "^0.10.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.30",
+    "autoprefixer": "^10.4.19",
+    "vite": "^4.4.9"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import Home from './pages/Home';
+import NewSOP from './pages/NewSOP';
+import EditSOP from './pages/EditSOP';
+
+export default function App() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="bg-blue-600 text-white p-4">
+        <div className="container mx-auto flex justify-between">
+          <h1 className="text-xl font-bold">
+            <Link to="/">SOP Creator</Link>
+          </h1>
+          <nav>
+            <Link className="mr-4" to="/">Home</Link>
+            <Link to="/new">New SOP</Link>
+          </nav>
+        </div>
+      </header>
+      <main className="flex-1 container mx-auto p-4">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/new" element={<NewSOP />} />
+          <Route path="/edit/:id" element={<EditSOP />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/src/components/ChecklistItem.jsx
+++ b/src/components/ChecklistItem.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function ChecklistItem({ item, onChange, onRemove }) {
+  return (
+    <div className="flex items-center mb-2">
+      <input
+        type="text"
+        className="border p-1 flex-1 mr-2"
+        value={item.text}
+        onChange={(e) => onChange({ ...item, text: e.target.value })}
+      />
+      <button className="text-red-500" onClick={onRemove}>x</button>
+    </div>
+  );
+}

--- a/src/components/SOPForm.jsx
+++ b/src/components/SOPForm.jsx
@@ -1,0 +1,121 @@
+import React, { useState, useEffect } from 'react';
+import StepBlock from './StepBlock';
+import { saveSOP, generateId } from '../lib/storage';
+import { generateMarkdown } from '../lib/markdown';
+import html2pdf from 'html2pdf.js';
+
+export default function SOPForm({ initialData }) {
+  const [title, setTitle] = useState(initialData?.title || '');
+  const [steps, setSteps] = useState(initialData?.steps || []);
+
+  useEffect(() => {
+    if (initialData) {
+      setTitle(initialData.title);
+      setSteps(initialData.steps);
+    }
+  }, [initialData]);
+
+  const addStep = () => {
+    setSteps([...steps, { title: '', description: '', checklist: [] }]);
+  };
+
+  const updateStep = (index, newStep) => {
+    const newSteps = steps.map((s, i) => (i === index ? newStep : s));
+    setSteps(newSteps);
+  };
+
+  const removeStep = (index) => {
+    setSteps(steps.filter((_, i) => i !== index));
+  };
+
+  const moveStep = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= steps.length) return;
+    const newSteps = [...steps];
+    const [moved] = newSteps.splice(index, 1);
+    newSteps.splice(newIndex, 0, moved);
+    setSteps(newSteps);
+  };
+
+  const handleSave = () => {
+    const id = initialData?.id || generateId();
+    saveSOP({ id, title, steps });
+    alert('Saved!');
+  };
+
+  const handleExportMarkdown = () => {
+    const markdown = generateMarkdown({ title, steps });
+    const blob = new Blob([markdown], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${title || 'sop'}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportPDF = () => {
+    const element = document.getElementById('sop-preview');
+    html2pdf().from(element).save(`${title || 'sop'}.pdf`);
+  };
+
+  const handleImport = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const data = JSON.parse(ev.target.result);
+      setTitle(data.title);
+      setSteps(data.steps);
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div>
+      <div className="mb-4">
+        <input
+          type="text"
+          className="border p-2 w-full mb-2"
+          placeholder="SOP Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <div className="space-x-2">
+          <button className="bg-blue-600 text-white px-4 py-2" onClick={handleSave}>Save</button>
+          <button className="bg-green-600 text-white px-4 py-2" onClick={addStep}>Add Step</button>
+          <button className="bg-gray-600 text-white px-4 py-2" onClick={handleExportMarkdown}>Export MD</button>
+          <button className="bg-gray-600 text-white px-4 py-2" onClick={handleExportPDF}>Export PDF</button>
+          <label className="bg-gray-200 px-4 py-2 cursor-pointer">
+            Import JSON
+            <input type="file" accept="application/json" className="hidden" onChange={handleImport} />
+          </label>
+        </div>
+      </div>
+      {steps.map((step, index) => (
+        <StepBlock
+          key={index}
+          step={step}
+          onChange={(s) => updateStep(index, s)}
+          onRemove={() => removeStep(index)}
+          onMoveUp={() => moveStep(index, -1)}
+          onMoveDown={() => moveStep(index, 1)}
+        />
+      ))}
+      <div id="sop-preview" className="hidden">
+        <h1>{title}</h1>
+        {steps.map((step, i) => (
+          <div key={i}>
+            <h2>{step.title}</h2>
+            <div dangerouslySetInnerHTML={{ __html: step.description }} />
+            <ul>
+              {step.checklist.map((item, idx) => (
+                <li key={idx}>{item.text}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/StepBlock.jsx
+++ b/src/components/StepBlock.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import ChecklistItem from './ChecklistItem';
+import MarkdownIt from 'markdown-it';
+
+const md = new MarkdownIt();
+
+export default function StepBlock({ step, onChange, onRemove, onMoveUp, onMoveDown }) {
+  const handleChecklistChange = (index, newItem) => {
+    const items = step.checklist.map((it, i) => (i === index ? newItem : it));
+    onChange({ ...step, checklist: items });
+  };
+
+  const handleChecklistRemove = (index) => {
+    const items = step.checklist.filter((_, i) => i !== index);
+    onChange({ ...step, checklist: items });
+  };
+
+  const addChecklistItem = () => {
+    onChange({ ...step, checklist: [...step.checklist, { text: '' }] });
+  };
+
+  return (
+    <div className="border p-4 mb-4 bg-white">
+      <div className="flex justify-between mb-2">
+        <input
+          type="text"
+          className="border p-1 flex-1 mr-2"
+          placeholder="Step Title"
+          value={step.title}
+          onChange={(e) => onChange({ ...step, title: e.target.value })}
+        />
+        <div className="space-x-2">
+          <button onClick={onMoveUp}>↑</button>
+          <button onClick={onMoveDown}>↓</button>
+          <button className="text-red-500" onClick={onRemove}>Delete</button>
+        </div>
+      </div>
+      <textarea
+        className="border p-1 w-full mb-2"
+        rows="4"
+        placeholder="Description (Markdown supported)"
+        value={step.description}
+        onChange={(e) => onChange({ ...step, description: e.target.value })}
+      />
+      <div className="prose mb-2" dangerouslySetInnerHTML={{ __html: md.render(step.description || '') }} />
+      <div>
+        <h4 className="font-semibold">Checklist</h4>
+        {step.checklist.map((item, index) => (
+          <ChecklistItem
+            key={index}
+            item={item}
+            onChange={(val) => handleChecklistChange(index, val)}
+            onRemove={() => handleChecklistRemove(index)}
+          />
+        ))}
+        <button className="text-blue-600" onClick={addChecklistItem}>Add Item</button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/markdown.js
+++ b/src/lib/markdown.js
@@ -1,0 +1,14 @@
+export function generateMarkdown({ title, steps }) {
+  let md = `# ${title}\n\n`;
+  steps.forEach((step, idx) => {
+    md += `## ${idx + 1}. ${step.title}\n\n`;
+    md += `${step.description}\n\n`;
+    if (step.checklist.length) {
+      step.checklist.forEach((item) => {
+        md += `- [ ] ${item.text}\n`;
+      });
+      md += '\n';
+    }
+  });
+  return md;
+}

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,0 +1,26 @@
+export function generateId() {
+  return '_' + Math.random().toString(36).substr(2, 9);
+}
+
+export function loadSOPList() {
+  const data = localStorage.getItem('sops');
+  return data ? JSON.parse(data) : [];
+}
+
+export function loadSOP(id) {
+  const list = loadSOPList();
+  return list.find((s) => s.id === id);
+}
+
+export function saveSOP(sop) {
+  const list = loadSOPList();
+  const existingIndex = list.findIndex((s) => s.id === sop.id);
+  if (existingIndex >= 0) list[existingIndex] = sop;
+  else list.push(sop);
+  localStorage.setItem('sops', JSON.stringify(list));
+}
+
+export function deleteSOP(id) {
+  const list = loadSOPList().filter((s) => s.id !== id);
+  localStorage.setItem('sops', JSON.stringify(list));
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/EditSOP.jsx
+++ b/src/pages/EditSOP.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import SOPForm from '../components/SOPForm';
+import { loadSOP } from '../lib/storage';
+
+export default function EditSOP() {
+  const { id } = useParams();
+  const data = loadSOP(id);
+
+  return (
+    <div>
+      <SOPForm initialData={data} />
+    </div>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { loadSOPList, deleteSOP } from '../lib/storage';
+
+export default function Home() {
+  const [sops, setSops] = useState([]);
+
+  useEffect(() => {
+    setSops(loadSOPList());
+  }, []);
+
+  const handleDelete = (id) => {
+    deleteSOP(id);
+    setSops(loadSOPList());
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">Saved SOPs</h2>
+      <ul>
+        {sops.map((sop) => (
+          <li key={sop.id} className="mb-2 flex justify-between items-center">
+            <Link className="text-blue-600" to={`/edit/${sop.id}`}>{sop.title}</Link>
+            <button className="text-red-500" onClick={() => handleDelete(sop.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/NewSOP.jsx
+++ b/src/pages/NewSOP.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import SOPForm from '../components/SOPForm';
+
+export default function NewSOP() {
+  return (
+    <div>
+      <SOPForm />
+    </div>
+  );
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('@tailwindcss/typography')],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- bootstrap Vite React app with TailwindCSS
- implement SOP creator with markdown preview, export/import, localStorage persistence
- add pages for home, new SOP and edit SOP
- add utility modules for storage and markdown generation
- document setup in README

## Testing
- `npm run build` *(fails: vite not found)*